### PR TITLE
Add support for alias nodes, and convert to numeric arrays when possible (as opposed to cell arrays of numbers)

### DIFF
--- a/README
+++ b/README
@@ -10,11 +10,9 @@ In dumping Matlab objects to YAML, arrays (of any type except char) become
 sequences, scalar structs become mappings, char arrays become strings, numeric
 values become floats, and logical values become bools. In loading YAML to
 Matlab, sequences become cell arrays, mappings become structs (if possible), and
-scalars are resolved according to their type. Because Matlab lacks a true
-reference type, documents that include aliases cannot be loaded using the simple
-interface. Note also that the Matlab -> YAML -> Matlab round-trip will not
-preserve the original data structure exactly (though recovering it should be
-fairly trivial in most cases).
+scalars are resolved according to their type. Note also that the
+Matlab -> YAML -> Matlab round-trip may not preserve the original data structure exactly
+(though recovering it should be fairly trivial in most cases).
 
 In addition to this simple high-level interface, Mat-YAML provides a lower-level
 means of representing YAML documents within Matlab which can be used as a basis

--- a/mex-src/yaml_mex_util.c
+++ b/mex-src/yaml_mex_util.c
@@ -562,7 +562,7 @@ void ymx_load_sequence( ymx_node_t *node,
     node->type = ymx_create_int_scalar(YMX_NODE_TYPE_SEQUENCE);
     
     size_t items_buffer_size = NODES_BUFFER_CHUNK_SIZE;
-    ymx_node_t *items = mxCalloc(items_buffer_size, sizeof(ymx_node_t *));
+    ymx_node_t *items = mxCalloc(items_buffer_size, sizeof(ymx_node_t));
     size_t num_items = 0;
     
     const yaml_event_t *event = ymx_parse(parser);
@@ -571,9 +571,9 @@ void ymx_load_sequence( ymx_node_t *node,
         if (num_items == items_buffer_size) {
             items_buffer_size += NODES_BUFFER_CHUNK_SIZE;
             items = mxRealloc(items,
-                    items_buffer_size * sizeof(ymx_node_t *));
+                    items_buffer_size * sizeof(ymx_node_t));
             memset(items + num_items, 0,
-                    NODES_BUFFER_CHUNK_SIZE * sizeof(ymx_node_t *));
+                    NODES_BUFFER_CHUNK_SIZE * sizeof(ymx_node_t));
         }
         ymx_load_node(items + num_items, parser, event);
         num_items++;
@@ -617,8 +617,8 @@ void ymx_load_mapping( ymx_node_t *node,
     node->type = ymx_create_int_scalar(YMX_NODE_TYPE_MAPPING);
     
     size_t buffer_size = NODES_BUFFER_CHUNK_SIZE;
-    ymx_node_t *keys   = mxCalloc(buffer_size, sizeof(ymx_node_t *));
-    ymx_node_t *values = mxCalloc(buffer_size, sizeof(ymx_node_t *));
+    ymx_node_t *keys   = mxCalloc(buffer_size, sizeof(ymx_node_t));
+    ymx_node_t *values = mxCalloc(buffer_size, sizeof(ymx_node_t));
     size_t num_items = 0;
     
     const yaml_event_t *event = ymx_parse(parser);
@@ -627,13 +627,13 @@ void ymx_load_mapping( ymx_node_t *node,
         if (num_items == buffer_size) {
             buffer_size += NODES_BUFFER_CHUNK_SIZE;
             keys = mxRealloc(keys,
-                    buffer_size * sizeof(ymx_node_t *));
+                    buffer_size * sizeof(ymx_node_t));
             memset(keys + num_items, 0,
-                    NODES_BUFFER_CHUNK_SIZE * sizeof(ymx_node_t *));
+                    NODES_BUFFER_CHUNK_SIZE * sizeof(ymx_node_t));
             values = mxRealloc(values,
-                    buffer_size * sizeof(ymx_node_t *));
+                    buffer_size * sizeof(ymx_node_t));
             memset(values + num_items, 0,
-                    NODES_BUFFER_CHUNK_SIZE * sizeof(ymx_node_t *));
+                    NODES_BUFFER_CHUNK_SIZE * sizeof(ymx_node_t));
         }
         
         ymx_load_node(keys + num_items, parser, event);

--- a/mex-src/yaml_mex_util.c
+++ b/mex-src/yaml_mex_util.c
@@ -1034,8 +1034,8 @@ void ymx_buffer_append(ymx_buffer_t *buffer,
     if (size > current_space) {
         /* We need to make some room */
         int required_chunks = 1 + (size-current_space)/buffer->chunk_size;
+        buffer->total_size += buffer->chunk_size * required_chunks;
         buffer->head = mxRealloc(buffer->head, buffer->total_size
-                + (buffer->chunk_size * required_chunks)
                 + YMX_BUFFER_TAIL_SIZE);
     }
     memcpy(buffer->head + buffer->used_size, input, size);

--- a/mfiles/yaml_simple_construct.m
+++ b/mfiles/yaml_simple_construct.m
@@ -1,7 +1,7 @@
-function data = yaml_simple_construct(yaml_node)
+function data = yaml_simple_construct(yaml_node , aliasMap , allow_new_alias)
 % yaml_simple_construct  Construct Matlab native data from YAML nodes
 % Usage:
-%     data = yaml_simple_construct(yaml_node)
+%     data = yaml_simple_construct( yaml_node )
 % Peforms a very simplistic construction of Matlab data types from a YAML
 % document or node, structured as output by yaml_mex (see "help yaml_mex").
 % This construction will attempt to follow the YAML 1.2 spec (although
@@ -9,10 +9,6 @@ function data = yaml_simple_construct(yaml_node)
 % reading a document with the "%YAML 1.2" directive), with some
 % limitations:
 % ---
-% Aliases:
-%   -> Matlab native data types don't implement references, so aliases
-%      won't work. These could be implemented with a user-defined handle
-%      subclass, but then it's no longer really a "simple" construction.
 % Mappings:
 %   -> The closest thing Matlab has to a native mapping type is a scalar
 %      struct. This is limited to keys that are valid Matlab identifiers.
@@ -47,6 +43,17 @@ function data = yaml_simple_construct(yaml_node)
 % OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 % USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+
+if nargin < 2
+    aliasMap = containers.Map;
+end
+
+if nargin < 3
+    %When we are resolving an aliased node, expect this input
+    % to be false.
+    allow_new_alias = true;
+end
+
 % If we received a document, get its root.
 if isfield(yaml_node, 'root')
     yaml_node = yaml_node.root;
@@ -58,13 +65,19 @@ switch yaml_node.type
     case 2 % sequence
         data = cell(size(yaml_node.value));
         for i=1:numel(yaml_node.value)
-            data{i} = yaml_simple_construct(yaml_node.value(i));
+            data{i} = yaml_simple_construct(yaml_node.value(i) , aliasMap , allow_new_alias);
         end
+        
+        %JDH MOD: detect numeric arrays
+        if all(cellfun(@(x) isa(x , 'double') , data))
+            data = cell2mat(data);
+        end
+        
     case 3 % mapping
         keys = {yaml_node.value(1,:).value};
         values = cell(size(keys));
         for i=1:size(yaml_node.value,2)
-            values{i} = {yaml_simple_construct(yaml_node.value(2,i))};
+            values{i} = {yaml_simple_construct(yaml_node.value(2,i) , aliasMap , allow_new_alias)};
         end
         data_arg = [keys;values];
         try
@@ -76,12 +89,27 @@ switch yaml_node.type
             end
         end
     case 4 % alias
-        error('yaml_simple_construct:aliasType', ...
-            'Cannot construct alias nodes.');
+        data = [];
+        if ~aliasMap.isKey(yaml_node.anchor)
+            warning('yaml_simple_construct:no_such_alias', 'Could not resolve alias ''%s''' , yaml_node.anchor);
+        else
+            aliasedNode = aliasMap(yaml_node.anchor);
+            data = yaml_simple_construct( aliasedNode , aliasMap , false);
+        end
     otherwise
-        error('yaml_simple_construct:unknownType', ...
+        data = [];
+        warning('yaml_simple_construct:unknownType', ...
             'Unrecognized node type.');
 end
+
+%Handle alias
+if allow_new_alias && ~isempty(yaml_node.anchor) && yaml_node.type ~=4
+    if aliasMap.isKey(yaml_node.anchor)
+        warning('yaml_simple_construct:duplicate_anchor' , 'found duplicate alias anchor: %s' , yaml_node.anchor);
+    end
+    aliasMap(yaml_node.anchor) = yaml_node; %#ok<NASGU>
+end
+    
 
 function data = construct_scalar(value, tag)
 if ismember(tag, {'!', 'tag:yaml.org,2002:str'})

--- a/mfiles/yaml_simple_construct.m
+++ b/mfiles/yaml_simple_construct.m
@@ -1,4 +1,4 @@
-function data = yaml_simple_construct(yaml_node , aliasMap , allow_new_alias)
+function data = yaml_simple_construct(yaml_node , varargin)
 % yaml_simple_construct  Construct Matlab native data from YAML nodes
 % Usage:
 %     data = yaml_simple_construct( yaml_node )
@@ -44,14 +44,22 @@ function data = yaml_simple_construct(yaml_node , aliasMap , allow_new_alias)
 % USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
+% Internally used (recursive) inputs to varargin:
+%     nargin 2, varargin{1} -- aliasMap, a containers.Map object
 if nargin < 2
     aliasMap = containers.Map;
+else
+    aliasMap = varargin{1};
 end
 
+% Internally used (recursive) inputs to varargin:
+%     nargin 3, varargin{2} -- allow_new_alias, logical flag
+%     When we are resolving an aliased node, expect this input
+%     to be false.
 if nargin < 3
-    %When we are resolving an aliased node, expect this input
-    % to be false.
     allow_new_alias = true;
+else
+    allow_new_alias = varargin{2};
 end
 
 % If we received a document, get its root.


### PR DESCRIPTION
Alias support added using builtin containers.Map object.